### PR TITLE
Avoid hardcoding the smoke-test image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -167,18 +167,6 @@ steps:
     waitFor:
       - build-smoke-test
 
-  - id: set-data-test-schema-default-values
-    name: gcr.io/cloud-marketplace-tools/k8s/dev
-    entrypoint: bash
-    args:
-      - -exc
-      - |
-        cat data-test/schema.yaml | env -i \
-          IMAGE=gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/smoke-test:${_APP_VERSION} \
-        envsubst | tee /dev/stderr > tmp && mv tmp data-test/schema.yaml
-    waitFor:
-      - "-"
-
   - id: build-deployer
     name: gcr.io/cloud-builders/docker
     args:
@@ -186,7 +174,7 @@ steps:
       - --tag
       - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/deployer:${_APP_VERSION}
       - "."
-    waitFor: ["set-data-test-schema-default-values"]
+    waitFor: ["-"]
 
   - id: push-deployer
     name: gcr.io/cloud-builders/docker

--- a/data-test/schema.yaml
+++ b/data-test/schema.yaml
@@ -7,14 +7,14 @@
 # To know more about the smoke tests:
 # https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/c5899a92/docs/mpdev-references.md#smoke-test-an-application
 
-properties:
-  smokeTestImage:
-    type: string
-    # These variables are envsubt'd in cloudbuild.yml
-    default: $IMAGE
-    x-google-property:
-      type: IMAGE
+x-google-marketplace:
+  images:
+    smoke-test:
+      properties:
+        smokeTestImage:
+          type: FULL
 
+properties:
   # We had to disable preflight so that `mpdev verify` would not fail. It
   # fails due to the fact that the preflight deployment never becomes
   # "ready" since the secret "agent-credentials" and the configmap


### PR DESCRIPTION
In this PR, I attempt using `x-google-marketplace.images.smoke-test` instead of `properties.smokeTestImage` in order to fix the "hardcoded tester image" issue.

Fixes #29 