### PR TITLE
Disable retagging in cloudbuild.yaml due to the licenses requirements

### DIFF
--- a/chart/jetstack-secure-gcm/charts/google-cas-issuer/values.yaml
+++ b/chart/jetstack-secure-gcm/charts/google-cas-issuer/values.yaml
@@ -26,10 +26,7 @@ prometheus:
   # Enables the creation of the ClusterIP service.
   enabled: true
 
-resources:
-  limits:
-    cpu: 200m
-    memory: 200Mi
-  requests:
-    cpu: 200m
-    memory: 200Mi
+resources: {}
+  # requests:
+  #   cpu: 10m
+  #   memory: 32Mi

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,128 +4,7 @@ substitutions:
   _CLUSTER_LOCATION: europe-west2-b
   _APP_VERSION: 1.1.0-gcm.1
   _SOLUTION_NAME: jetstack-secure-for-cert-manager
-  _CERT_MANAGER_VERSION: 1.1.0
-  _CAS_ISSUER_VERSION: 0.1.0
-  _PREFLIGHT_VERSION: 0.1.27
 steps:
-  - id: pull-preflight
-    name: gcr.io/cloud-builders/docker
-    args:
-      - pull
-      - quay.io/jetstack/preflight:v${_PREFLIGHT_VERSION}
-    waitFor: ["-"]
-
-  - id: tag-preflight
-    name: gcr.io/cloud-builders/docker
-    args:
-      - tag
-      - quay.io/jetstack/preflight:v${_PREFLIGHT_VERSION}
-      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/cert-manager-preflight:${_APP_VERSION}
-    waitFor:
-      - pull-preflight
-
-  - id: push-preflight
-    name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/cert-manager-preflight:${_APP_VERSION}
-    waitFor:
-      - tag-preflight
-
-  - id: pull-cas-issuer
-    name: gcr.io/cloud-builders/docker
-    args:
-      - pull
-      - quay.io/jetstack/cert-manager-google-cas-issuer:${_CAS_ISSUER_VERSION}
-    waitFor: ["-"]
-
-  - id: tag-cas-issuer
-    name: gcr.io/cloud-builders/docker
-    args:
-      - tag
-      - quay.io/jetstack/cert-manager-google-cas-issuer:${_CAS_ISSUER_VERSION}
-      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/cert-manager-google-cas-issuer:${_APP_VERSION}
-    waitFor:
-      - pull-cas-issuer
-
-  - id: push-cas-issuer
-    name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/cert-manager-google-cas-issuer:${_APP_VERSION}
-    waitFor:
-      - tag-cas-issuer
-
-  - id: pull-controller
-    name: gcr.io/cloud-builders/docker
-    args:
-      - pull
-      - quay.io/jetstack/cert-manager-controller:v${_CERT_MANAGER_VERSION}
-    waitFor: ["-"]
-
-  - id: pull-cainjector
-    name: gcr.io/cloud-builders/docker
-    args:
-      - pull
-      - quay.io/jetstack/cert-manager-cainjector:v${_CERT_MANAGER_VERSION}
-    waitFor: ["-"]
-
-  - id: pull-webhook
-    name: gcr.io/cloud-builders/docker
-    args:
-      - pull
-      - quay.io/jetstack/cert-manager-webhook:v${_CERT_MANAGER_VERSION}
-    waitFor: ["-"]
-
-  - id: tag-controller
-    name: gcr.io/cloud-builders/docker
-    args:
-      - tag
-      - quay.io/jetstack/cert-manager-controller:v${_CERT_MANAGER_VERSION}
-      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}:${_APP_VERSION}
-    waitFor:
-      - pull-controller
-
-  - id: tag-cainjector
-    name: gcr.io/cloud-builders/docker
-    args:
-      - tag
-      - quay.io/jetstack/cert-manager-cainjector:v${_CERT_MANAGER_VERSION}
-      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/cert-manager-cainjector:${_APP_VERSION}
-    waitFor:
-      - pull-cainjector
-
-  - id: tag-webhook
-    name: gcr.io/cloud-builders/docker
-    args:
-      - tag
-      - quay.io/jetstack/cert-manager-webhook:v${_CERT_MANAGER_VERSION}
-      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/cert-manager-webhook:${_APP_VERSION}
-    waitFor:
-      - pull-webhook
-
-  - id: push-controller
-    name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}:${_APP_VERSION}
-    waitFor:
-      - tag-controller
-
-  - id: push-cainjector
-    name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/cert-manager-cainjector:${_APP_VERSION}
-    waitFor:
-      - tag-cainjector
-
-  - id: push-webhook
-    name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/cert-manager-webhook:${_APP_VERSION}
-
   - id: pull-ubbagent
     name: gcr.io/cloud-builders/docker
     args:
@@ -271,12 +150,6 @@ steps:
         kubectl logs -n "$ns" $pod -f --tail=-1
     waitFor:
       - check-cloud-marketplace-tools
-      - push-deployer
-      - push-controller
-      - push-cainjector
-      - push-webhook
-      - push-cas-issuer
-      - push-preflight
       - push-ubbagent
 
   - id: logs-smoke-test
@@ -300,12 +173,6 @@ steps:
         kubectl logs -n "$ns" smoke-test-pod -f --tail=-1
     waitFor:
       - check-cloud-marketplace-tools
-      - push-deployer
-      - push-controller
-      - push-cainjector
-      - push-webhook
-      - push-cas-issuer
-      - push-preflight
       - push-ubbagent
       - push-smoke-test
 
@@ -324,12 +191,6 @@ steps:
       - --deployer=gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/deployer:${_APP_VERSION}
     waitFor:
       - check-cloud-marketplace-tools
-      - push-deployer
-      - push-controller
-      - push-cainjector
-      - push-webhook
-      - push-cas-issuer
-      - push-preflight
       - push-ubbagent
       - push-smoke-test
 
@@ -348,11 +209,6 @@ steps:
       - verify
 
 images:
-  - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}:${_APP_VERSION}
-  - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/cert-manager-cainjector:${_APP_VERSION}
-  - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/cert-manager-webhook:${_APP_VERSION}
-  - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/cert-manager-google-cas-issuer:${_APP_VERSION}
-  - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/cert-manager-preflight:${_APP_VERSION}
   - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/deployer:${_APP_VERSION}
   - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/ubbagent:${_APP_VERSION}
   - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/smoke-test:${_APP_VERSION}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,7 +2,12 @@ timeout: 1800s # 30m
 substitutions:
   _CLUSTER_NAME: cluster-1
   _CLUSTER_LOCATION: europe-west2-b
-  _APP_VERSION: 1.1.0-gcm.1
+  # The deployer version must always be a minor version at any time since
+  # the Marketplace UI will only accept minor tags for the deployer.
+  _DEPLOYER_VERSION: "1.1"
+  # The _APP_VERSION must be equal to the value set on the publishedVersion
+  # field in schema.yaml.
+  _APP_VERSION: "1.1.0-gcm.1"
   _SOLUTION_NAME: jetstack-secure-for-cert-manager
 steps:
   - id: pull-ubbagent
@@ -58,7 +63,8 @@ steps:
     waitFor:
       - "-"
 
-  - id: build-deployer
+  # We push a deployer:1.1.0-gcm.1 for our debugging purposes.
+  - id: build-deployer-using-app-version
     name: gcr.io/cloud-builders/docker
     args:
       - build
@@ -67,13 +73,32 @@ steps:
       - "."
     waitFor: ["set-data-test-schema-default-values"]
 
-  - id: push-deployer
+  - id: push-deployer-using-app-version
     name: gcr.io/cloud-builders/docker
     args:
       - push
       - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/deployer:${_APP_VERSION}
     waitFor:
-      - build-deployer
+      - build-deployer-using-app-version
+
+  # The tag deployer:1.1 (for example) is the actual "important" image
+  # since it is the one that will be used in the Marketplace UI.
+  - id: tag-deployer-using-minor-version
+    name: gcr.io/cloud-builders/docker
+    args:
+      - tag
+      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/deployer:${_APP_VERSION}
+      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/deployer:${_DEPLOYER_VERSION}
+    waitFor:
+      - build-deployer-using-app-version
+
+  - id: push-deployer-using-minor-version
+    name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/deployer:${_APP_VERSION}
+    waitFor:
+      - tag-deployer-using-minor-version
 
   - id: gcloud-credentials
     name: gcr.io/cloud-builders/gcloud
@@ -210,5 +235,6 @@ steps:
 
 images:
   - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/deployer:${_APP_VERSION}
+  - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/deployer:${_DEPLOYER_VERSION}
   - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/ubbagent:${_APP_VERSION}
   - gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/smoke-test:${_APP_VERSION}

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -175,7 +175,7 @@ steps:
         kubectl logs -n "$ns" $pod -f --tail=-1
     waitFor:
       - check-cloud-marketplace-tools
-      - push-ubbagent
+      - push-deployer-using-minor-version
 
   - id: logs-smoke-test
     name: gcr.io/cloud-builders/gcloud
@@ -198,7 +198,6 @@ steps:
         kubectl logs -n "$ns" smoke-test-pod -f --tail=-1
     waitFor:
       - check-cloud-marketplace-tools
-      - push-ubbagent
       - push-smoke-test
 
   - id: verify
@@ -216,6 +215,7 @@ steps:
       - --deployer=gcr.io/$PROJECT_ID/${_SOLUTION_NAME}/deployer:${_APP_VERSION}
     waitFor:
       - check-cloud-marketplace-tools
+      - push-deployer-using-minor-version
       - push-ubbagent
       - push-smoke-test
 

--- a/docs/TESTING-DEPLOYER.md
+++ b/docs/TESTING-DEPLOYER.md
@@ -20,16 +20,19 @@ the image embeds:
 - The `helm` tool,
 - The Helm charts for cert-manager, google-cas-issuer and preflight.
 
-The deployer image looks like this:
+There are two deployer tags:
 
 ```sh
+# The main moving tag required by the Marketplace UI:
 marketplace.gcr.io/jetstack-public/jetstack-secure-for-cert-manager/deployer:1.1
+
+# A static tag for debugging purposes:
+marketplace.gcr.io/jetstack-public/jetstack-secure-for-cert-manager/deployer:1.1.0-gcm.1
 ```
 
-We provide one single tag for the deployer image. That is due to the fact
-that the Marketplace UI only works with minor versions (e.g., `1.1`). If we
-were to push other tags (e.g., `1.1.0` or `1.1.0-gcm.1`), they would not be
-used anyways:
+The minor tag `1.1` (for example) is the tag that the Marketplace UI needs.
+The other tags (e.g., `1.1.0` or `1.1.0-gcm.1`) cannot be used for the
+Marketplace UI:
 
 > A version should correspond to a minor version (e.g. `1.0`) according to
 > semantic versioning  (not a patch version, such as `1.1.0`). Update the
@@ -41,9 +44,9 @@ In the below screenshot, we see that both the deployer tags `1.1.0` and
 
 <img src="https://user-images.githubusercontent.com/2195781/110091031-491bed00-7d98-11eb-8522-ddc91913d010.png" width="500" alt="Only the minor version 1.1 should be pushed, not 1.1.0 or 1.1.0-gcm.1. This screenshot is stored in this issue: https://github.com/jetstack/jetstack-secure-gcm/issues/21">
 
-Important: although we only push the minor tag for the deployer image, we
-still push "full" tags for all the other images. For example, let us
-imagine that `deployer:1.1` was created with this `schema.yaml`:
+Note that we only push full tags (e.g., `1.1.0-gcm.1`) for all the other
+images. For example, let us imagine that `deployer:1.1` was created with
+this `schema.yaml`:
 
 ```yaml
 # schema.yaml
@@ -82,6 +85,7 @@ As a recap about image tags, here is what the tags look like now, taking
 ```sh
 # The deployer image is built and pushed in cloudbuild.yaml:
 gcr.io/jetstack-public/jetstack-secure-for-cert-manager/deployer:1.1
+gcr.io/jetstack-public/jetstack-secure-for-cert-manager/deployer:1.1.0-gcm.1
 
 # These images are manually pushed (see below command):
 gcr.io/jetstack-public/jetstack-secure-for-cert-manager:1.1.0-gcm.1 # this is cert-manager-controller


### PR DESCRIPTION
As part of #29, I had to disable the re-tagging/re-pushing of all the images in cloudbuild.md is that we do not want to 'override' the OSPO-approved (open source program office) that are currently in the registry.

In order to retag all `google-review` images to `1.1.0-gcm.1` since we don't have yet automated Google-OSPO-compliant image (automation will be done in [#10](https://github.com/jetstack/jetstack-secure-gcm/issues/10)):

```sh
while read img; do
    docker pull $img:google-review
    docker tag $img:{google-review,1.1.0-gcm.1}
    docker push $img:1.1.0-gcm.1
done <<EOF
gcr.io/jetstack-public/jetstack-secure-for-cert-manager
gcr.io/jetstack-public/jetstack-secure-for-cert-manager/cert-manager-acmesolver
gcr.io/jetstack-public/jetstack-secure-for-cert-manager/cert-manager-cainjector
gcr.io/jetstack-public/jetstack-secure-for-cert-manager/cert-manager-webhook
gcr.io/jetstack-public/jetstack-secure-for-cert-manager/cert-manager-google-cas-issuer
gcr.io/jetstack-public/jetstack-secure-for-cert-manager/preflight
EOF
```

As part of this PR, I also documented all the intricacies about the deployer tag.