### PR TITLE
Fix schema yaml too large

### DIFF
--- a/docs/TESTING-DEPLOYER.md
+++ b/docs/TESTING-DEPLOYER.md
@@ -303,8 +303,8 @@ the steps taken in each release directly on the GitHub Release itself in a
 For example, when releasing `1.1.0-gcm.5`, the steps were:
 
 1. Copy the `<details>` block from the previous release [1.1.0-gcm.4](https://github.com/jetstack/jetstack-secure-gcm/releases/tag/1.1.0-gcm.4)
-2. In an editor, change the references to 1.1.0-gcm.4
-3. Follow the steps and tick the checkboxes
+2. In an editor, change the references to `1.1.0-gcm.4`.
+3. Follow the steps and tick the checkboxes.
 4. After the `1.1.0-gcm.5` is pushed to GitHub, create a GitHub Release for that
    tag and paste the content the `<details>` block to the GitHub Release.
 

--- a/schema.yaml
+++ b/schema.yaml
@@ -6,9 +6,6 @@
 
 x-google-marketplace:
   schemaVersion: v2
-
-  # MUST match the version of the Application custom resource object.
-  # This is the same as the top level applicationApiVersion field in v1.beta1
   applicationApiVersion: v1beta1
 
   # We are not "truely" following semver.org since we use a "-" for a final
@@ -21,23 +18,11 @@ x-google-marketplace:
   publishedVersionMetadata:
     releaseNote: >-
       Initial release.
-    # releaseTypes list is optional.
-    # "Security" should only be used if this is an important update to patch
-    # an existing vulnerability, as such updates will display more prominently for users.
-    releaseTypes:
-      - Feature
-      - BugFix
-      - Security
-    # If "recommended" is "true", users using older releases are encouraged
-    # to update as soon as possible. This is useful if, for example, this release
-    # fixes a critical issue.
+    # Means that this upgrade is very much encouraged (e.g. security reasons)
     recommended: true
 
   # Image declaration is required here. Refer to the Images section below.
   images:
-    # The Marketplace requires us to use a "primary image". In our case,
-    # this is cert-manager-controller. See "primary image" in
-    # https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/d9d3a6/docs/schema.md
     "": # This is cert-manager-controller.
       properties:
         cert-manager.image.repository:

--- a/schema.yaml
+++ b/schema.yaml
@@ -14,7 +14,7 @@ x-google-marketplace:
   #
   # Important: it must have the same value as the version in the
   # Application manifest.
-  publishedVersion: "1.1.0-gcm.6"
+  publishedVersion: "1.1.0-gcm.7"
   publishedVersionMetadata:
     releaseNote: >-
       Initial release.


### PR DESCRIPTION
In an [email](https://groups.google.com/a/jetstack.io/g/cert-manager-maintainers/c/lQo2Ct5VMt4/m/IwMvnVvmBAAJ) from Dinesh:

> Your schema.yaml is too large -- can you please clear comments from schema.yaml file repo, build the new deployer image and resubmit the draft for review. This should get the file below the 16384 size limit.

I removed a couple of comments in order to go under 16384 bytes... 😆