### PR TITLE
Make the preflight deployment green on a fresh deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,12 @@ When you are done, click the "Deploy" button:
 This will install Jetstack Secure for cert-manager, and will redirect to
 the [Applications](https://console.cloud.google.com/kubernetes/application) page:
 
-<img src="https://user-images.githubusercontent.com/2195781/112529074-28e2bb00-8da5-11eb-9aca-f347fbfe0330.png" width="600" alt="The Application view on GKE after deploying the application test-1 onto the test-1 namespace. This screenshot is stored in this issue: https://github.com/jetstack/jetstack-secure-gcm/issues/21">
+<img src="https://user-images.githubusercontent.com/2195781/110795922-a96acd00-8277-11eb-959e-bf7ea51ae992.png" width="500" alt="The application page for test-1 shows that all the deployments are green. This screenshot is stored in this issue: https://github.com/jetstack/jetstack-secure-gcm/issues/21">
 
-**Note:** the preflight deployment is expected to be failing when the
-application is first deployed. After registering your cluster on
-<https://platform.jetstack.io>, the deployment will start working. To register your cluster, keep reading the [next section](#step-2-log-into-the-jetstack-secure-dashboard).
+**Note:** by default, the `preflight` deployment is scaled to 0. After
+completing the steps in the [next
+section](#step-2-log-into-the-jetstack-secure-dashboard), the deployment will
+start working.
 
 ### Step 2: log into the Jetstack Secure dashboard
 
@@ -192,6 +193,7 @@ You can then apply the Jetstack Secure agent configuration to your cluster:
 
 ```sh
 sed '/namespace:/d' agent-config.yaml | kubectl -n $NAMESPACE apply -f-
+kubectl -n $NAMESPACE scale --replicas=1 $(kubectl -n $NAMESPACE get deploy -oname | grep preflight)
 kubectl -n $NAMESPACE rollout restart $(kubectl -n $NAMESPACE get deploy -oname | grep preflight)
 ```
 

--- a/README.md
+++ b/README.md
@@ -189,11 +189,16 @@ gcloud auth login
 gcloud container clusters get-credentials --zone=$LOCATION $CLUSTER
 ```
 
+You will now be able to "activate" the Preflight deployment:
+
+```sh
+kubectl -n $NAMESPACE scale deploy --replicas=1 --selector=app.kubernetes.io/component=preflight
+```
+
 You can then apply the Jetstack Secure agent configuration to your cluster:
 
 ```sh
 sed '/namespace:/d' agent-config.yaml | kubectl -n $NAMESPACE apply -f-
-kubectl -n $NAMESPACE scale --replicas=1 $(kubectl -n $NAMESPACE get deploy -oname | grep preflight)
 kubectl -n $NAMESPACE rollout restart $(kubectl -n $NAMESPACE get deploy -oname | grep preflight)
 ```
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Here is the command shown in the below screenshot that you can copy-paste
 for your convenience:
 
 ```sh
-kubectl -n $NAMESPACE get pod -l app.kubernetes.io/name=preflight
+kubectl -n $NAMESPACE get pod -l app.kubernetes.io/component=preflight
 ```
 
 <img src="https://user-images.githubusercontent.com/2195781/109156984-ca102e80-7771-11eb-9087-56c2b2781108.png" width="600px" alt="Use kubectl to check that the pod is ready. This screenshot is stored in this issue: https://github.com/jetstack/jetstack-secure-gcm/issues/21">
@@ -221,7 +221,7 @@ kubectl -n $NAMESPACE get pod -l app.kubernetes.io/name=preflight
 You should eventually see that the pod is `READY 1/1`:
 
 ```sh
-% kubectl -n $NAMESPACE get pod -l app.kubernetes.io/name=preflight
+% kubectl -n $NAMESPACE get pod -l app.kubernetes.io/component=preflight
 NAME                                         READY   STATUS     AGE
 jetstack-secure-preflight-6b8d5ccb6f-6gnjm   1/1     Running    20h
 ```

--- a/chart/jetstack-secure-gcm/values.yaml
+++ b/chart/jetstack-secure-gcm/values.yaml
@@ -56,6 +56,9 @@ google-cas-issuer:
     tag: 1.1.0-gcm.1
 
 preflight:
+  # By default, the preflight deployment is "disabled" by setting replicas=0.
+  # See https://github.com/jetstack/jetstack-secure-gcm/issues/41
+  replicas: 0
   nameOverride: jetstack-secure-gcm
   fullnameOverride: preflight
   serviceAccount:

--- a/data-test/schema.yaml
+++ b/data-test/schema.yaml
@@ -19,11 +19,3 @@ properties:
     default: $IMAGE
     x-google-property:
       type: IMAGE
-
-  # We had to disable preflight so that `mpdev verify` would not fail. It
-  # fails due to the fact that the preflight deployment never becomes
-  # "ready" since the secret "agent-credentials" and the configmap
-  # "agent-config" are absent from the cluster.
-  preflight.replicaCount:
-    type: integer
-    default: 0

--- a/schema.yaml
+++ b/schema.yaml
@@ -14,7 +14,7 @@ x-google-marketplace:
   #
   # Important: it must have the same value as the version in the
   # Application manifest.
-  publishedVersion: "1.1.0-gcm.7"
+  publishedVersion: "1.1.0-gcm.8"
   publishedVersionMetadata:
     releaseNote: >-
       Initial release.


### PR DESCRIPTION
As discussed in #41 and after a [bit of feedback](https://groups.google.com/a/jetstack.io/g/cert-manager-maintainers/c/lQo2Ct5VMt4/m/QMMo5wzJBQAJ) from Dinesh (from Google, in charge of reviewing the Marketplace apps), we decided to change the way the preflight deployment is deployed to make sure it shows "green" after a fresh click-to-deploy. Initially, we thought that it would make sense to leave the preflight deployment to fail on a fresh install in order to "indicate" that action was needed to set up <http://platform.jetstack.io/>, but we later realized that it led to a poor UX.

Before/after:
  <img src="https://user-images.githubusercontent.com/2195781/110791519-9acde700-8272-11eb-81f4-4f27fb8a174d.png" width="300" alt="The test-1 application page on GKE should show the test-1 application. The preflight deployment is failing because the user has not (yet) gone to http://platform.jetstack.io/ to register their cluster. This screenshot is stored in this issue: https://github.com/jetstack/jetstack-secure-gcm/issues/21"> <img src="https://user-images.githubusercontent.com/2195781/110795922-a96acd00-8277-11eb-959e-bf7ea51ae992.png" width="300" alt="The application page for test-1 shows that all the deployments are green. This screenshot is stored in this issue: https://github.com/jetstack/jetstack-secure-gcm/issues/21">

Fixes #41