### PR TITLE
Add a note about the billing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,12 @@ local workstation to complete these steps.
 
 [![Open in Cloud Shell](http://gstatic.com/cloudssh/images/open-btn.svg)](https://console.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/jetstack/jetstack-secure-gcm&cloudshell_working_dir=/)
 
+The pricing using the CLI to install is identical to using the click-to-deploy
+method: each cluster is priced at $50 a month, billed hourly ($0.07/hour). Note
+that the cert-manager controller deployment should always have a number of
+replicas equal to 1. High-availability for the cert-manager controller is not
+supported yet.
+
 ### Prerequisites
 
 #### Set up command line tools


### PR DESCRIPTION
This PR fixes one comment from @wallrj that I left over in https://github.com/jetstack/jetstack-secure-gcm/pull/40:

> If I was going to nitpick, I'd probably ask for even more detail on the pricing mechanism and ubbagent, but that can be in a followup.
>
> I see there's a note about pricing in https://console.cloud.google.com/marketplace/details/jetstack-public/jetstack-secure-for-cert-manager?project=jetstack-public&authuser=0, and I wondered if that should also be added to the README file in this repo, for the benefit of users who take the CLI installation route.

/cc @wallrj 

