### PR TITLE
Add a cloudbuild for running go-providence-checker on all images

### DIFF
--- a/chart/jetstack-secure-gcm/values.yaml
+++ b/chart/jetstack-secure-gcm/values.yaml
@@ -58,7 +58,7 @@ google-cas-issuer:
 preflight:
   # By default, the preflight deployment is "disabled" by setting replicas=0.
   # See https://github.com/jetstack/jetstack-secure-gcm/issues/41
-  replicas: 0
+  replicaCount: 0
   nameOverride: jetstack-secure-gcm
   fullnameOverride: preflight
   serviceAccount:

--- a/cloudbuild-retag-with-licenses.yaml
+++ b/cloudbuild-retag-with-licenses.yaml
@@ -1,0 +1,97 @@
+timeout: 1800s # 30m
+substitutions:
+  _APP_VERSION: "0.1.0-build"
+
+  # Git tags.
+  _CERT_MANAGER_TAG: "v1.3.1"
+  _JETSTACK_AGENT_TAG: "v0.1.29"
+  _GOOGLE_CAS_ISSUER_TAG: "v0.3.0"
+  _GOOGLE_CAS_ISSUER_TAG_DOCKER: "0.3.0"
+steps:
+  - id: get-go-providence-checker
+    name: gcr.io/cloud-builders/go
+    entrypoint: sh
+    args:
+      - -exc
+      - |
+        GO111MODULE=on go get github.com/jakexks/go-providence-checker@32cc49d3aa0bba6bf268b047857d63156056e74b
+        mv $(go env GOPATH)/bin/go-providence-checker /workspace
+
+  - id: licenses-for-cert-manager
+    name: gcr.io/cloud-builders/go
+    entrypoint: sh
+    args:
+      - -exc
+      # We use --force in the below command because we are doing our best to
+      # fetch all possible licenses, but since the tree is enormous, we skip the
+      # modules that have a missing or unrecognized license.
+      - |
+        mkdir licenses-for-cert-manager
+        cd licenses-for-cert-manager/ && GO111MODULE=on /workspace/go-providence-checker dependencies --force --debug github.com/jetstack/cert-manager@${_CERT_MANAGER_TAG}
+    waitFor: [get-go-providence-checker]
+
+  - id: licenses-for-jetstack-agent
+    name: gcr.io/cloud-builders/go
+    entrypoint: sh
+    args:
+      - -exc
+      - |
+        mkdir licenses-for-jetstack-agent
+        cd licenses-for-jetstack-agent/ && GO111MODULE=on /workspace/go-providence-checker dependencies --force --debug github.com/jetstack/preflight@${_JETSTACK_AGENT_TAG}
+    waitFor: [get-go-providence-checker]
+
+  - id: licenses-for-google-cas-issuer
+    name: gcr.io/cloud-builders/go
+    entrypoint: sh
+    args:
+      - -exc
+      - |
+        mkdir licenses-for-google-cas-issuer
+        cd licenses-for-google-cas-issuer/ && GO111MODULE=on /workspace/go-providence-checker dependencies --force --debug github.com/jetstack/google-cas-issuer@${_GOOGLE_CAS_ISSUER_TAG}
+    waitFor: [get-go-providence-checker]
+
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -exc
+      # The retag script retags as well as adds the licenses to the image. The
+      # LICENsES_DIR is the directory where LICENSES.txt and thirdparty/ folder
+      # are.
+      #
+      # Usage: retag <LICENSES_DIR> <FROM_IMAGE> <TO_IMAGE>
+      - |
+        cat <<'EOF' > ./retag && chmod +x ./retag
+        #! /bin/bash
+        set -ueo pipefail
+        dir_to_copy=$1
+        from=$2
+        to=$3
+        docker pull $from
+        temp=$(docker create $from)
+        docker cp $dir_to_copy $temp:/
+        docker commit $temp $to
+        docker push $to
+        EOF
+
+        ./retag ./licenses-for-cert-manager quay.io/jetstack/cert-manager-controller:${_CERT_MANAGER_TAG} gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager:${_APP_VERSION}
+        ./retag ./licenses-for-cert-manager quay.io/jetstack/cert-manager-acmesolver:${_CERT_MANAGER_TAG} gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-acmesolver:${_APP_VERSION}
+        ./retag ./licenses-for-cert-manager quay.io/jetstack/cert-manager-cainjector:${_CERT_MANAGER_TAG} gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-cainjector:${_APP_VERSION}
+        ./retag ./licenses-for-cert-manager quay.io/jetstack/cert-manager-webhook:${_CERT_MANAGER_TAG} gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-webhook:${_APP_VERSION}
+        ./retag ./licenses-for-cert-manager quay.io/jetstack/cert-manager-webhook:${_CERT_MANAGER_TAG} gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-webhook:${_APP_VERSION}
+        ./retag ./licenses-for-jetstack-agent quay.io/jetstack/preflight:${_JETSTACK_AGENT_TAG} gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/preflight:${_APP_VERSION}
+        ./retag ./licenses-for-google-cas-issuer quay.io/jetstack/cert-manager-google-cas-issuer:${_GOOGLE_CAS_ISSUER_TAG_DOCKER} gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-google-cas-issuer:${_APP_VERSION}
+    waitFor:
+      [
+        licenses-for-cert-manager,
+        licenses-for-jetstack-agent,
+        licenses-for-google-cas-issuer,
+      ]
+
+images:
+  - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager:${_APP_VERSION}
+  - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-acmesolver:${_APP_VERSION}
+  - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-cainjector:${_APP_VERSION}
+  - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-webhook:${_APP_VERSION}
+  - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-webhook:${_APP_VERSION}
+  - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/preflight:${_APP_VERSION}
+  - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-google-cas-issuer:${_APP_VERSION}

--- a/cloudbuild-retag-with-licenses.yaml
+++ b/cloudbuild-retag-with-licenses.yaml
@@ -87,6 +87,15 @@ steps:
         licenses-for-google-cas-issuer,
       ]
 
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -exc
+      - |
+        docker pull gcr.io/cloud-marketplace-tools/metering/ubbagent:latest
+        docker tag gcr.io/cloud-marketplace-tools/metering/ubbagent:latest gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/ubbagent:${_APP_VERSION}
+        docker push gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/ubbagent:${_APP_VERSION}
+
 images:
   - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager:${_APP_VERSION}
   - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-acmesolver:${_APP_VERSION}
@@ -95,3 +104,4 @@ images:
   - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-webhook:${_APP_VERSION}
   - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/preflight:${_APP_VERSION}
   - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/cert-manager-google-cas-issuer:${_APP_VERSION}
+  - gcr.io/$PROJECT_ID/jetstack-secure-for-cert-manager/ubbagent:${_APP_VERSION}

--- a/schema.yaml
+++ b/schema.yaml
@@ -212,18 +212,35 @@ properties:
               - apiGroups: ["cert-manager.io"]
                 resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
                 verbs: ["get", "list", "watch"]
+              # To be removed when this gets merged: https://github.com/jetstack/cert-manager/issues/3726
               - apiGroups: ["extensions"]
                 resources: ["ingresses"]
                 verbs: ["get", "list", "watch"]
+              # To be removed when this gets merged: https://github.com/jetstack/cert-manager/issues/3726
               - apiGroups: ["extensions"]
                 resources: ["ingresses/finalizers"]
                 verbs: ["update"]
+              - apiGroups: ["networking.k8s.io"]
+                resources: ["ingresses/finalizers"]
+                verbs: ["update"]
+              - apiGroups: ["networking.k8s.io"]
+                resources: ["ingresses"]
+                verbs: ["get", "list", "watch"]
               - apiGroups: [""]
                 resources: ["events"]
                 verbs: ["create", "patch"]
               - apiGroups: [""]
                 resources: ["configmaps"]
                 verbs: ["get", "create", "update", "patch"]
+              - apiGroups: ["cert-manager.io"]
+                resources: ["signers"]
+                verbs: ["approve"]
+                resourceNames:
+                  - "issuers.cert-manager.io/*"
+                  - "clusterissuers.cert-manager.io/*"
+                  # Approval API, see https://github.com/jetstack/google-cas-issuer/pull/34/files#diff-80390a
+                  - googlecasclusterissuers.cas-issuer.jetstack.io/*
+                  - googlecasissuers.cas-issuer.jetstack.io/*
 
   cert-manager.webhook.serviceAccount.name:
     type: string
@@ -239,6 +256,12 @@ properties:
               - apiGroups: [""]
                 resources: [secrets]
                 verbs: [get, list, watch, update, patch, create]
+          - type: ClusterRole
+            rulesType: CUSTOM
+            rules:
+              - apiGroups: ["authorization.k8s.io"]
+                resources: ["subjectaccessreviews"]
+                verbs: ["create"]
 
   cert-manager.cainjector.serviceAccount.name:
     type: string

--- a/schema.yaml
+++ b/schema.yaml
@@ -14,7 +14,7 @@ x-google-marketplace:
   #
   # Important: it must have the same value as the version in the
   # Application manifest.
-  publishedVersion: "1.1.0-gcm.8"
+  publishedVersion: 1.3.1-gcm.0
   publishedVersionMetadata:
     releaseNote: >-
       Initial release.


### PR DESCRIPTION
This PR adds a new cloudbuild file that pushes the license-compliant images (cert-manager-controller, cainjector, etc).

To run it:

```
gcloud builds submit --project jetstack-public --config cloudbuild-retag-with-licenses.yaml \
  --substitutions _APP_VERSION=1.3.1-gcm.0,_CERT_MANAGER_TAG=v1.3.1
```

In this PR also:
- I fixed a bug with preflight's replicas (I wrote `replicas` instead of `replicaCount`).
- With Jake, we added three missing RBAC rules that were added in cert-manager 1.3.0.

Fixes #10 