### PR TITLE
Ensure that gcloud project is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,12 @@ Configure `gcloud` as a Docker credential helper:
 gcloud auth configure-docker
 ```
 
+Set `gcloud` to use your project:
+
+```sh
+gcloud config set project <project-name>
+```
+
 #### Create a Google Kubernetes Engine cluster
 
 The [workload


### PR DESCRIPTION
A user reported that they couldn't follow the CLI instructions, and it
became clear it was failing because their gcloud didn't have a default
project.

Add a pre-requisite step to set the project so that this can't happen.