### PR TITLE
The Secret in license.yaml not matching the CLI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,7 +670,7 @@ helm template "$APP_INSTANCE_NAME" chart/jetstack-secure-gcm \
   --set preflight.serviceAccount.create=true \
   --set preflight.rbac.create=true \
   --set cert-manager.ubbagent.image.tag="$TAG" \
-  --set cert-manager.ubbagent.reportingSecretName=$APP_INSTANCE_NAME-license \
+  --set cert-manager.ubbagent.reportingSecretName=jetstack-secure-for-cert-mana-1-license \
   > "${APP_INSTANCE_NAME}_manifest.yaml"
 ```
 


### PR DESCRIPTION
In the README, there is a mismatch between the Secret name that is being used in the Helm chart and the Secret name that is downloaded in the "Command line tab" (file name `license.yaml`).

In the README:

![Screenshot from 2021-06-04 16-41-12-3](https://user-images.githubusercontent.com/2195781/120819663-12e73880-c554-11eb-90f8-f45d5c33cff9.png)
![Screenshot from 2021-06-04 16-41-12-2](https://user-images.githubusercontent.com/2195781/120819505-ec290200-c553-11eb-8c83-3deeff666341.png)


By default, the README's Secret name is:

```
jetstack-secure-1-license
```

In the downloaded `license.yaml`:

![issue](https://user-images.githubusercontent.com/2195781/120819927-58a40100-c554-11eb-9726-20c4b1d139aa.png)

After a couple of trials and errors, I discovered that the Secret name inside this `license.yaml` is always the same:

```
jetstack-secure-for-cert-mana-1-license
```

I propose to hardcode this secret name since it seems to relate to the Google Cloud Marketplace application name.

cc @james-w 