### PR TITLE
Release new version with cert-manager 1.4.3

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -14,7 +14,7 @@ x-google-marketplace:
   #
   # Important: it must have the same value as the version in the
   # Application manifest.
-  publishedVersion: 1.4.0-gcm.0
+  publishedVersion: 1.4.3-gcm.0
   publishedVersionMetadata:
     releaseNote: >-
       Initial release.


### PR DESCRIPTION
We've built a new deployer image using cert-manager 1.4.3 and submitted it for review by Google.

Draft release: https://github.com/jetstack/jetstack-secure-gcm/releases/tag/untagged-0c062d284ec12763fe80
Deployer image: https://console.cloud.google.com/gcr/images/jetstack-public/GLOBAL/jetstack-secure-for-cert-manager/deployer@sha256:62dab3167397f710c00b7d7826576bcb5b4b7a03696c3704f7eb5646f7583c2e/details?tab=info