### PR TITLE
Release v1.5.4

### DIFF
--- a/chart/jetstack-secure-gcm/charts/cert-manager/templates/startupapicheck-psp-clusterrole.yaml
+++ b/chart/jetstack-secure-gcm/charts/cert-manager/templates/startupapicheck-psp-clusterrole.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.global.podSecurityPolicy.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "startupapicheck.fullname" . }}-psp
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "startupapicheck"
+    {{- include "labels" . | nindent 4 }}
+  {{- if .Values.startupapicheck.rbac.annotations }}
+  annotations:
+    {{ toYaml .Values.startupapicheck.rbac.annotations | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "startupapicheck.fullname" . }}
+{{- end }}
+{{- end }}

--- a/chart/jetstack-secure-gcm/charts/cert-manager/templates/startupapicheck-psp-clusterrolebinding.yaml
+++ b/chart/jetstack-secure-gcm/charts/cert-manager/templates/startupapicheck-psp-clusterrolebinding.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.global.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "startupapicheck.fullname" . }}-psp
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "startupapicheck"
+    {{- include "labels" . | nindent 4 }}
+  {{- if .Values.startupapicheck.rbac.annotations }}
+  annotations:
+    {{ toYaml .Values.startupapicheck.rbac.annotations | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "startupapicheck.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "startupapicheck.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/schema.yaml
+++ b/schema.yaml
@@ -11,7 +11,7 @@ x-google-marketplace:
   # We are not "truely" following semver.org since we use a "-" for a final
   # release ("-" is meant for pre-releases). This is due to a Docker
   # limitation: https://github.com/distribution/distribution/issues/1201
-  publishedVersion: 1.5.3-gcm.0
+  publishedVersion: 1.5.4-gcm.0
   publishedVersionMetadata:
     releaseNote: >-
       Initial release.


### PR DESCRIPTION
Commands I ran to find the missing Helm chart parts from the upstream cert-manager project:

```
# From cert-manager project:
git fetch --tags
git diff v1.5.3 v1.5.4 -- deploy/charts/cert-manager/templates
cd deploy/charts/cert-manager/templates
cp startupapicheck-psp-clusterrolebinding.yaml startupapicheck-psp-clusterrole.yaml \
  ~/code/jetstack/jetstack-secure-gcm/chart/jetstack-secure-gcm/charts/cert-manager/templates
```

Deployer logs: https://console.cloud.google.com/cloud-build/builds/f5ced2aa-3c04-4b50-b3ec-8f0126d13500?project=885059085598
Draft release: https://github.com/jetstack/jetstack-secure-gcm/releases/tag/untagged-f23097134f172e08bf2e
